### PR TITLE
Design an normales WP-Design anpassen

### DIFF
--- a/html/form.html
+++ b/html/form.html
@@ -11,68 +11,28 @@
         <link rel="stylesheet" href="<!-- %wp-includes% -->css/buttons.min.css" />
         <link rel="stylesheet" href='<!-- %wp-admin% -->css/login.min.css' />
 
-        <style>
-            a {
-                top: 10px;
-                display: table;
-                position: absolute;
-                text-decoration: none;
-            }
-            a.back {
-                left: 20px;
-            }
-            a.wpcoder {
-                right: 20px;
-            }
-            form {
-                top: 50%;
-                left: 50%;
-                width: 260px;
-                display: block;
-                margin: -130px 0 0 -130px;
-                position: absolute;
-                text-align: center;
-            }
-            input {
-                width: 100%;
-                display: inline-block;
-            }
-            input[type="text"] {
-                margin: 5px 0;
-                height: 50px;
-                font-size: 30px;
-                line-height: 50px;
-                text-align: center;
-            }
-
-            @media only screen and (max-width: 480px) {
-                a.wpcoder {
-                    top: auto;
-                    right: 0;
-                    bottom: 20px;
-                    width: 100%;
-                    text-align: center;
-                }
-            }
-        </style>
-
         <title>
             Abfrage des Sicherheitscodes
         </title>
     </head>
 
-    <body class="wp-core-ui">
-        <a href="<!-- %login_url% -->" class="back">← Zurück zum Login</a>
-        <a href="http://wpcoder.de" target="_blank" class="wpcoder">Plugin von Sergej Müller</a>
-
-        <form action="" method="post">
-            <p>
-                An deine E-Mail-Adresse wurde ein Sicherheitscode verschickt.<br />Der Code läuft in 5 Minuten ab.
-            </p>
-
-            <input type="text" name="_auth_token" placeholder="CODE" maxlength="5" autocomplete="off" autocorrect="off" spellcheck="false" required />
-            <input type="submit" class="button button-primary" value="Sicherheitscode verifizieren" />
-            <!-- %nonce_field% -->
-        </form>
+    <body class="login login-action-login wp-core-ui">
+        
+		<div id="login">
+			<p class="message">An deine E-Mail-Adresse wurde ein Sicherheitscode verschickt.<br />Der Code läuft in 5 Minuten ab.</p>
+			<form name="loginform" id="loginform" action="" method="post">
+				<p>
+					<label for="user_login">Sicherheitscode<br />
+					<input type="text" name="_auth_token" maxlength="5" autocomplete="off" autocorrect="off" spellcheck="false" required /></label>
+				</p>
+				<input type="submit" class="button button-primary" value="Sicherheitscode verifizieren" />
+				<!-- %nonce_field% -->
+			</form>
+			
+			<p id="nav">
+				<a href="<!-- %login_url% -->" class="back">&larr; Zurück zum Login</a><br />
+				<a href="http://wpcoder.de" target="_blank" class="wpcoder">Plugin von Sergej Müller</a>
+			</p>		
+		</div>
     </body>
 </html>


### PR DESCRIPTION
Design des Eingabeformulars an das WordPress-Login-Design angepasst.
Das könnte vor allem für neue Benutzer, die über das Plugin gestolpert sind hilfreich sein.